### PR TITLE
fix: a few links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.amundsen.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 #Links within the site
-documentation: "https://lyft.github.io/amundsen/"
-getstarted: "https://lyft.github.io/amundsen/"
+documentation: "https://www.amundsen.io/amundsen/"
+getstarted: "https://www.amundsen.io/amundsen/"
 youtube: "https://www.youtube.com/playlist?list=PL0UJdxehTNlKnGU_h7k2fzJyvAiufeh1U"
 github: "https://github.com/lyft/amundsen"
 community: "https://join.slack.com/t/amundsenworkspace/shared_invite/enQtNTk2ODQ1NDU1NDI0LTc3MzQyZmM0ZGFjNzg5MzY1MzJlZTg4YjQ4YTU0ZmMxYWU2MmVlMzhhY2MzMTc1MDg0MzRjNTA4MzRkMGE0Nzk"

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ getstarted: "https://www.amundsen.io/amundsen/"
 youtube: "https://www.youtube.com/playlist?list=PL0UJdxehTNlKnGU_h7k2fzJyvAiufeh1U"
 github: "https://github.com/amundsen-io/amundsen"
 community: "https://join.slack.com/t/amundsenworkspace/shared_invite/enQtNTk2ODQ1NDU1NDI0LTc3MzQyZmM0ZGFjNzg5MzY1MzJlZTg4YjQ4YTU0ZmMxYWU2MmVlMzhhY2MzMTc1MDg0MzRjNTA4MzRkMGE0Nzk"
-medium: "https://github.com/lyft/amundsen#blog-posts-and-interviews"
+medium: "https://github.com/amundsen-io/amundsen#blog-posts-and-interviews"
 
 destination: dist
 

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ url: "https://www.amundsen.io" # the base hostname & protocol for your site, e.g
 documentation: "https://www.amundsen.io/amundsen/"
 getstarted: "https://www.amundsen.io/amundsen/"
 youtube: "https://www.youtube.com/playlist?list=PL0UJdxehTNlKnGU_h7k2fzJyvAiufeh1U"
-github: "https://github.com/lyft/amundsen"
+github: "https://github.com/amundsen-io/amundsen"
 community: "https://join.slack.com/t/amundsenworkspace/shared_invite/enQtNTk2ODQ1NDU1NDI0LTc3MzQyZmM0ZGFjNzg5MzY1MzJlZTg4YjQ4YTU0ZmMxYWU2MmVlMzhhY2MzMTc1MDg0MzRjNTA4MzRkMGE0Nzk"
 medium: "https://github.com/lyft/amundsen#blog-posts-and-interviews"
 


### PR DESCRIPTION
Fix broken doc links after amundsen-io move. Most notably the `Get Started` doc link front and center on https://www.amundsen.io/ still points to the old Lyft doc site. Whick give you a 404 like experience.

Congrats on the move BTW. Very exciting times for Amundsen!
